### PR TITLE
Add tslint for linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "clean": "rm -rf ./dist",
     "build": "npm run clean && tsc && cp -r ./src/artifacts ./dist/src/ && cp ./src/*.json ./dist/src/ && cp -r ./src/lib ./dist/src/",
+    "lint": "tslint src/**/*.ts",
     "test": "npm run build && node ./dist/test/test",
     "testunit": "npm run build && mocha --timeout 15000 dist/test/unit/*.js ",
     "testdeploy": "npm run build && node ./dist/test/deploy",
@@ -25,6 +26,7 @@
     "dirty-chai": "^2.0.1",
     "mocha": "^4.0.1",
     "ts-node": "^3.3.0",
+    "tslint": "^5.8.0",
     "typings": "^2.1.1"
   },
   "dependencies": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,9 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {},
+    "rulesDirectory": []
+}

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,10 @@
         "tslint:recommended"
     ],
     "jsRules": {},
-    "rules": {},
+    "rules": {
+      "indent": [true, "spaces", 4],
+      "quotemark": [true, "single"],
+      "curly": [true, "ignore-same-line"]
+    },
     "rulesDirectory": []
 }

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,8 @@
     "rules": {
       "indent": [true, "spaces", 4],
       "quotemark": [true, "single"],
-      "curly": [true, "ignore-same-line"]
+      "curly": [true, "ignore-same-line"],
+      "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Linting the project will become very handy once more people start contributing. 

Once there are no more lint error it would be worth adding `npm run lint` to a git pre-commit hook so that all the small errors get caught before they make it into the repository.