### PR TITLE
Make npm run build work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "ethereum"
   ],
   "scripts": {
-    "clean": "rm -rf ./dist",
-    "build": "npm run clean && tsc && cp -r ./src/artifacts ./dist/src/ && cp ./src/*.json ./dist/src/ && cp -r ./src/lib ./dist/src/",
+    "clean": "rimraf ./dist ",
+    "build": "npm run clean && tsc && shx mkdir dist && shx mkdir dist/src && shx cp -r ./src/artifacts ./dist/src/ && shx cp ./src/*.json ./dist/src/ && shx cp -r ./src/lib ./dist/src/",
     "lint": "tslint --project tsconfig.json -c tslint.json",
     "test": "npm run build && node ./dist/test/test",
     "testunit": "npm run build && mocha --timeout 15000 dist/test/unit/**/*.js",
@@ -26,6 +26,8 @@
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
     "mocha": "^4.0.1",
+    "rimraf": "2.6.2",
+    "shx": "0.2.2",
     "ts-node": "^3.3.0",
     "tslint": "^5.8.0",
     "typings": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "clean": "rimraf ./dist",
-    "build": "npm run clean && tsc && shx mkdir dist && shx mkdir dist/src && shx cp -r ./src/artifacts ./dist/src/ && shx cp ./src/*.json ./dist/src/ && shx cp -r ./src/lib ./dist/src/",
+    "build": "npm run clean && tsc && shx cp -r ./src/artifacts ./dist/src/ && shx cp ./src/*.json ./dist/src/ && shx cp -r ./src/lib ./dist/src/",
     "lint": "tslint --project tsconfig.json -c tslint.json",
     "test": "npm run build && node ./dist/test/test",
     "testunit": "npm run build && mocha --timeout 15000 dist/test/unit/**/*.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ethereum"
   ],
   "scripts": {
-    "clean": "rimraf ./dist ",
+    "clean": "rimraf ./dist",
     "build": "npm run clean && tsc && shx mkdir dist && shx mkdir dist/src && shx cp -r ./src/artifacts ./dist/src/ && shx cp ./src/*.json ./dist/src/ && shx cp -r ./src/lib ./dist/src/",
     "lint": "tslint --project tsconfig.json -c tslint.json",
     "test": "npm run build && node ./dist/test/test",


### PR DESCRIPTION
Make `npm run build` platform agnostic by using platform independent build and clean scripts